### PR TITLE
Refactor WorkItemPoller by removing sprint summary logic

### DIFF
--- a/backend/notifications/notificationService.js
+++ b/backend/notifications/notificationService.js
@@ -191,10 +191,6 @@ class NotificationService {
     const message = markdownFormatter.formatOverdueItemsMessage(overdueItems);
     await this.sendNotification(message, 'overdue-reminder');
   }
-
-  async sendSprintSummary(summary) {
-    await this.sendNotification(summary, 'sprint-summary');
-  }
 }
 
 export const notificationService = new NotificationService();

--- a/backend/polling/workItemPoller.js
+++ b/backend/polling/workItemPoller.js
@@ -1,6 +1,5 @@
 import { logger } from '../utils/logger.js';
 import { azureDevOpsClient } from '../devops/azureDevOpsClient.js';
-import { aiService } from '../ai/aiService.js';
 import { notificationService } from '../notifications/notificationService.js';
 
 class WorkItemPoller {
@@ -13,16 +12,11 @@ class WorkItemPoller {
     try {
       logger.info('Starting work items polling');
 
-      // Get current sprint work items
+      // Get current sprint work items for monitoring purposes
       const sprintWorkItems = await azureDevOpsClient.getCurrentSprintWorkItems();
       
       if (sprintWorkItems.count > 0) {
         logger.info(`Found ${sprintWorkItems.count} work items in current sprint`);
-        
-        // Generate and send daily sprint summary (only once per day)
-        if (this.shouldSendDailySummary()) {
-          await this.sendSprintSummary(sprintWorkItems.value);
-        }
       } else {
         logger.info('No work items found in current sprint');
       }
@@ -48,40 +42,6 @@ class WorkItemPoller {
     } catch (error) {
       logger.error('Error checking overdue items:', error);
     }
-  }
-
-  async sendSprintSummary(workItems) {
-    try {
-      logger.info('Generating sprint summary');
-
-      const summary = await aiService.summarizeSprintWorkItems(workItems);
-      await notificationService.sendSprintSummary(summary);
-      
-      logger.info('Sprint summary sent successfully');
-    } catch (error) {
-      logger.error('Error sending sprint summary:', error);
-    }
-  }
-
-  shouldSendDailySummary() {
-    const now = new Date();
-    const lastSummaryDate = this.getLastSummaryDate();
-    
-    // Send summary once per day at 9 AM or later
-    return (
-      now.getHours() >= 9 && 
-      (!lastSummaryDate || now.toDateString() !== lastSummaryDate.toDateString())
-    );
-  }
-
-  getLastSummaryDate() {
-    // In a real implementation, this would be stored in a database or file
-    // For now, we'll use a simple in-memory approach
-    return this.lastSummaryDate || null;
-  }
-
-  setLastSummaryDate(date) {
-    this.lastSummaryDate = date;
   }
 }
 


### PR DESCRIPTION
Eliminate the `sendSprintSummary` method and related logic from the `WorkItemPoller` class to streamline the code and focus on current sprint work items.